### PR TITLE
chore: remove debug echo statement from SQS message polling

### DIFF
--- a/Model/QueuedTask.php
+++ b/Model/QueuedTask.php
@@ -293,7 +293,6 @@ class QueuedTask extends QueueAppModel {
 
 
         if(!$result || !$result->get('Messages')) {
-            echo "\nNo messages\n";
             return [];
         }
         $message = $result->get('Messages')[0];


### PR DESCRIPTION
Remove noisy "No messages" console output that clutters worker logs when the queue is empty.